### PR TITLE
Reflect the transfer to voxpupuli/ruby-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ jobs:
       id-token: write
 
     steps:
-      - uses: ekohl/ruby-release@v0
+      - uses: voxpupuli/ruby-release@v0
 ```


### PR DESCRIPTION

This repository is now maintained under the Vox Pupuli umbrella and users should no longer use the old name.
