### PR TITLE
Add reusable gem release workflow

### DIFF
--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -1,0 +1,126 @@
+---
+name: Reusable Gem Release
+
+on:
+  workflow_call:
+    inputs:
+      allowed_owner:
+        description: Repository owner allowed to publish
+        required: true
+        type: string
+      environment:
+        description: GitHub environment for RubyGems trusted publishing
+        required: false
+        default: release
+        type: string
+      ruby_version:
+        description: Ruby version used to build and verify the gem
+        required: false
+        default: ruby
+        type: string
+      publish_github_packages:
+        description: Publish the built gem to GitHub Packages
+        required: false
+        default: true
+        type: boolean
+
+permissions: {}
+
+jobs:
+  build-release:
+    name: Build the gem
+    if: github.repository_owner == inputs.allowed_owner
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby_version }}
+      - name: Build gem
+        shell: bash
+        run: gem build --verbose *.gemspec
+      - name: Upload gem artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gem-artifact
+          path: '*.gem'
+          retention-days: 1
+          compression-level: 0
+
+  create-github-release:
+    name: Create GitHub release
+    needs: build-release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download gem artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Create release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create --repo ${{ github.repository }} ${{ github.ref_name }} --generate-notes *.gem
+
+  release-to-github-packages:
+    name: Release gem to GitHub Packages
+    if: inputs.publish_github_packages
+    needs: build-release
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - name: Download gem artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Publish gem to GitHub Packages
+        shell: bash
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+        run: gem push --host https://rubygems.pkg.github.com/${{ github.repository_owner }} *.gem
+
+  release-to-rubygems:
+    name: Release gem to rubygems.org
+    needs: build-release
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Download gem artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - uses: rubygems/configure-rubygems-credentials@v1.0.0
+      - name: Publish gem to rubygems.org
+        shell: bash
+        run: gem push *.gem
+
+  release-verification:
+    name: Verify RubyGems propagation
+    needs:
+      - create-github-release
+      - release-to-rubygems
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Download gem artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby_version }}
+      - name: Wait for release to propagate
+        shell: bash
+        run: |
+          gem install rubygems-await
+          gem await *.gem

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Unlike [rubygems/release-gem](https://github.com/rubygems/release-gem) this uses
 
 It assumes you have a single gemspec file in your repository root.
 
-## Example usage
+## Composite action usage
 
 This assumes you push a tag and it releases to Rubygems. It also uses the `release` environment, which is optional but recommended.
 
@@ -33,3 +33,45 @@ jobs:
     steps:
       - uses: voxpupuli/ruby-release@v0
 ```
+
+## Reusable workflow usage
+
+If you want a release pipeline with separated permissions, GitHub release creation,
+GitHub Packages publishing, and RubyGems trusted publishing in dedicated jobs,
+use the reusable workflow instead of the composite action:
+
+```yaml
+---
+name: Gem Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions: {}
+
+jobs:
+  release:
+    uses: voxpupuli/ruby-release/.github/workflows/gem-release.yml@v0
+    with:
+      allowed_owner: 'MyOwner'
+      environment: 'release'
+```
+
+### Inputs
+
+- `allowed_owner`: repository owner allowed to publish. This blocks releases from forks.
+- `environment`: GitHub environment used for RubyGems trusted publishing. Defaults to `release`.
+- `ruby_version`: Ruby version used to build and verify the gem. Defaults to `ruby`.
+- `publish_github_packages`: whether to also publish to GitHub Packages. Defaults to `true`.
+
+### When to use what
+
+- Use the composite action when you only need a small direct RubyGems release job.
+- Use the reusable workflow when you want:
+  - minimal permissions per job
+  - GitHub release creation
+  - optional GitHub Packages publishing
+  - artifact handoff between build and publish steps
+  - a structure that is easy to roll out through modulesync


### PR DESCRIPTION
## Summary
- add a reusable workflow for gem releases with separated permissions
- keep the existing composite action path for lightweight direct RubyGems releases
- document when callers should use the reusable workflow instead

## What this adds
- build job with artifact handoff
- GitHub release creation job
- optional GitHub Packages publishing job
- RubyGems trusted publishing job using OIDC
- release verification step using rubygems-await

## Why
The current `action.yml` is a composite action, which is convenient for simple releases but cannot separate permissions per stage. This reusable workflow mirrors the multi-job shape already proven in `voxpupuli/gem-workflow-test` and gives downstream gem repos a single reusable entrypoint that is easier to roll out through modulesync later.

Related to voxpupuli/community-triage#38.